### PR TITLE
Update .utcnow() deprecated method in datetime

### DIFF
--- a/deribit/websockets/dbt-ws-authenticated-example.py
+++ b/deribit/websockets/dbt-ws-authenticated-example.py
@@ -17,7 +17,7 @@ import sys
 import json
 import logging
 from typing import Dict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 # installed
 import websockets
@@ -25,11 +25,8 @@ import websockets
 
 class main:
     def __init__(
-        self,
-        ws_connection_url: str,
-        client_id: str,
-        client_secret: str
-            ) -> None:
+        self, ws_connection_url: str, client_id: str, client_secret: str
+    ) -> None:
         # Async Event Loop
         self.loop = asyncio.get_event_loop()
 
@@ -42,17 +39,15 @@ class main:
         self.refresh_token_expiry_time: int = None
 
         # Start Primary Coroutine
-        self.loop.run_until_complete(
-            self.ws_manager()
-            )
+        self.loop.run_until_complete(self.ws_manager())
 
     async def ws_manager(self) -> None:
         async with websockets.connect(
             self.ws_connection_url,
             ping_interval=None,
             compression=None,
-            close_timeout=60
-            ) as self.websocket_client:
+            close_timeout=60,
+        ) as self.websocket_client:
 
             # Authenticate WebSocket Connection
             await self.ws_auth()
@@ -61,51 +56,54 @@ class main:
             await self.establish_heartbeat()
 
             # Start Authentication Refresh Task
-            self.loop.create_task(
-                self.ws_refresh_auth()
-                )
+            self.loop.create_task(self.ws_refresh_auth())
 
             # Subscribe to the specified WebSocket Channel
             self.loop.create_task(
                 self.ws_operation(
-                    operation='subscribe',
-                    ws_channel='trades.BTC-PERPETUAL.raw'
-                    )
+                    operation="subscribe", ws_channel="trades.BTC-PERPETUAL.raw"
                 )
+            )
 
             while self.websocket_client.open:
                 message: bytes = await self.websocket_client.recv()
                 message: Dict = json.loads(message)
-                # logging.info(message)
+                logging.info(message)
 
-                if 'id' in list(message):
-                    if message['id'] == 9929:
+                if "id" in list(message):
+                    if message["id"] == 9929:
                         if self.refresh_token is None:
-                            logging.info('Successfully authenticated WebSocket Connection')
+                            logging.info(
+                                "Successfully authenticated WebSocket Connection"
+                            )
                         else:
-                            logging.info('Successfully refreshed the authentication of the WebSocket Connection')
+                            logging.info(
+                                "Successfully refreshed the authentication of the WebSocket Connection"
+                            )
 
-                        self.refresh_token = message['result']['refresh_token']
+                        self.refresh_token = message["result"]["refresh_token"]
 
                         # Refresh Authentication well before the required datetime
-                        if message['testnet']:
+                        if message["testnet"]:
                             expires_in: int = 300
                         else:
-                            expires_in: int = message['result']['expires_in'] - 240
+                            expires_in: int = message["result"]["expires_in"] - 240
 
-                        self.refresh_token_expiry_time = datetime.utcnow() + timedelta(seconds=expires_in)
+                        self.refresh_token_expiry_time = datetime.now(
+                            timezone.utc
+                        ) + timedelta(seconds=expires_in)
 
-                    elif message['id'] == 8212:
+                    elif message["id"] == 8212:
                         # Avoid logging Heartbeat messages
                         continue
 
-                elif 'method' in list(message):
+                elif "method" in list(message):
                     # Respond to Heartbeat Message
-                    if message['method'] == 'heartbeat':
+                    if message["method"] == "heartbeat":
                         await self.heartbeat_response()
 
             else:
-                logging.info('WebSocket connection has broken.')
+                logging.info("WebSocket connection has broken.")
                 sys.exit(1)
 
     async def establish_heartbeat(self) -> None:
@@ -114,19 +112,13 @@ class main:
         establish a heartbeat connection.
         """
         msg: Dict = {
-                    "jsonrpc": "2.0",
-                    "id": 9098,
-                    "method": "public/set_heartbeat",
-                    "params": {
-                              "interval": 10
-                               }
-                    }
+            "jsonrpc": "2.0",
+            "id": 9098,
+            "method": "public/set_heartbeat",
+            "params": {"interval": 10},
+        }
 
-        await self.websocket_client.send(
-            json.dumps(
-                msg
-                )
-                )
+        await self.websocket_client.send(json.dumps(msg))
 
     async def heartbeat_response(self) -> None:
         """
@@ -134,17 +126,13 @@ class main:
         the Deribit API Heartbeat message.
         """
         msg: Dict = {
-                    "jsonrpc": "2.0",
-                    "id": 8212,
-                    "method": "public/test",
-                    "params": {}
-                    }
+            "jsonrpc": "2.0",
+            "id": 8212,
+            "method": "public/test",
+            "params": {},
+        }
 
-        await self.websocket_client.send(
-            json.dumps(
-                msg
-                )
-                )
+        await self.websocket_client.send(json.dumps(msg))
 
     async def ws_auth(self) -> None:
         """
@@ -152,21 +140,17 @@ class main:
         authenticate the WebSocket Connection.
         """
         msg: Dict = {
-                    "jsonrpc": "2.0",
-                    "id": 9929,
-                    "method": "public/auth",
-                    "params": {
-                              "grant_type": "client_credentials",
-                              "client_id": self.client_id,
-                              "client_secret": self.client_secret
-                               }
-                    }
+            "jsonrpc": "2.0",
+            "id": 9929,
+            "method": "public/auth",
+            "params": {
+                "grant_type": "client_credentials",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+            },
+        }
 
-        await self.websocket_client.send(
-            json.dumps(
-                msg
-                )
-            )
+        await self.websocket_client.send(json.dumps(msg))
 
     async def ws_refresh_auth(self) -> None:
         """
@@ -175,30 +159,22 @@ class main:
         """
         while True:
             if self.refresh_token_expiry_time is not None:
-                if datetime.utcnow() > self.refresh_token_expiry_time:
+                if datetime.now(timezone.utc) > self.refresh_token_expiry_time:
                     msg: Dict = {
-                                "jsonrpc": "2.0",
-                                "id": 9929,
-                                "method": "public/auth",
-                                "params": {
-                                          "grant_type": "refresh_token",
-                                          "refresh_token": self.refresh_token
-                                            }
-                                }
+                        "jsonrpc": "2.0",
+                        "id": 9929,
+                        "method": "public/auth",
+                        "params": {
+                            "grant_type": "refresh_token",
+                            "refresh_token": self.refresh_token,
+                        },
+                    }
 
-                    await self.websocket_client.send(
-                        json.dumps(
-                            msg
-                            )
-                            )
+                    await self.websocket_client.send(json.dumps(msg))
 
             await asyncio.sleep(150)
 
-    async def ws_operation(
-        self,
-        operation: str,
-        ws_channel: str
-            ) -> None:
+    async def ws_operation(self, operation: str, ws_channel: str) -> None:
         """
         Requests `public/subscribe` or `public/unsubscribe`
         to DBT's API for the specific WebSocket Channel.
@@ -206,41 +182,35 @@ class main:
         await asyncio.sleep(5)
 
         msg: Dict = {
-                    "jsonrpc": "2.0",
-                    "method": f"public/{operation}",
-                    "id": 42,
-                    "params": {
-                        "channels": [ws_channel]
-                        }
-                    }
+            "jsonrpc": "2.0",
+            "method": f"public/{operation}",
+            "id": 42,
+            "params": {"channels": [ws_channel]},
+        }
 
-        await self.websocket_client.send(
-            json.dumps(
-                msg
-                )
-            )
+        await self.websocket_client.send(json.dumps(msg))
 
 
 if __name__ == "__main__":
     # Logging
     logging.basicConfig(
-        level='INFO',
-        format='%(asctime)s | %(levelname)s | %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-        )
+        level="INFO",
+        format="%(asctime)s | %(levelname)s | %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
 
     # DBT LIVE WebSocket Connection URL
     # ws_connection_url: str = 'wss://www.deribit.com/ws/api/v2'
     # DBT TEST WebSocket Connection URL
-    ws_connection_url: str = 'wss://test.deribit.com/ws/api/v2'
+    ws_connection_url: str = "wss://test.deribit.com/ws/api/v2"
 
     # DBT Client ID
-    client_id: str = '<client-id>'
+    client_id: str = "<client-id>"
     # DBT Client Secret
-    client_secret: str = '<client_secret>'
+    client_secret: str = "<client_secret>"
 
     main(
-         ws_connection_url=ws_connection_url,
-         client_id=client_id,
-         client_secret=client_secret
-         )
+        ws_connection_url=ws_connection_url,
+        client_id=client_id,
+        client_secret=client_secret,
+    )


### PR DESCRIPTION
The method .utcnow() from datetime is now deprecated. To reproduce the same behavior, use `datetime.now(datetime.timezone.utc)` and import timezone from datetime. This commit applies this change.
